### PR TITLE
Added option to remove app icon from launcher.

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -16,10 +16,19 @@
             android:label="@string/app_name" >
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
+            </intent-filter>
+        </activity>
+
+        <activity-alias
+            android:name="com.afzaln.awakedebug.MainActivityAlias"
+            android:enabled="true"
+            android:targetActivity="com.afzaln.awakedebug.MainActivity">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
 
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
-        </activity>
+        </activity-alias>
 
         <receiver android:name=".PowerConnectionReceiver">
             <intent-filter>

--- a/app/src/main/java/com/afzaln/awakedebug/AppIconHideHelper.java
+++ b/app/src/main/java/com/afzaln/awakedebug/AppIconHideHelper.java
@@ -10,6 +10,8 @@ import android.widget.CheckBox;
 import android.widget.CompoundButton;
 
 /**
+ * This allows the user to remove the app icon from the launcher.
+ *
  * Created by Dan Mercer (Github: drmercer) on 6/11/16.
  */
 public class AppIconHideHelper implements CompoundButton.OnCheckedChangeListener {
@@ -34,6 +36,7 @@ public class AppIconHideHelper implements CompoundButton.OnCheckedChangeListener
         mCheckBox.setEnabled(enabled);
         if (!enabled) {
             mCheckBox.setChecked(false);
+            mDialogHasBeenSeen = false; // Clear flag so that the dialog can reappear
         }
     }
 
@@ -47,6 +50,7 @@ public class AppIconHideHelper implements CompoundButton.OnCheckedChangeListener
         // Show warning dialog on first time
         if (!mDialogHasBeenSeen && isChecked) {
             mDialogHasBeenSeen = true;
+            mCheckBox.setChecked(false); // Un-check the CheckBox (in case they dismiss the dialog)
 
             AlertDialog.Builder db = new AlertDialog.Builder(mActivity);
             db.setMessage(R.string.icon_warning);
@@ -56,6 +60,7 @@ public class AppIconHideHelper implements CompoundButton.OnCheckedChangeListener
                 @Override
                 public void onClick(DialogInterface dialog, int which) {
                     changeIconVisibility(true); // Hide icon
+                    mCheckBox.setChecked(true); // Re-check the CheckBox
                 }
             });
 
@@ -63,7 +68,6 @@ public class AppIconHideHelper implements CompoundButton.OnCheckedChangeListener
             db.setNegativeButton(R.string.no, new DialogInterface.OnClickListener() {
                 @Override
                 public void onClick(DialogInterface dialog, int which) {
-                    mCheckBox.setChecked(false); // Un-check the CheckBox
                     mDialogHasBeenSeen = false; // Clear flag.
                 }
             });

--- a/app/src/main/java/com/afzaln/awakedebug/AppIconHideHelper.java
+++ b/app/src/main/java/com/afzaln/awakedebug/AppIconHideHelper.java
@@ -1,0 +1,105 @@
+package com.afzaln.awakedebug;
+
+import android.app.Activity;
+import android.app.AlertDialog;
+import android.content.ComponentName;
+import android.content.DialogInterface;
+import android.content.pm.PackageManager;
+import android.preference.PreferenceManager;
+import android.widget.CheckBox;
+import android.widget.CompoundButton;
+
+/**
+ * Created by Dan Mercer (Github: drmercer) on 6/11/16.
+ */
+public class AppIconHideHelper implements CompoundButton.OnCheckedChangeListener {
+    private final Activity mActivity;
+    private CheckBox mCheckBox;
+    private boolean mDialogHasBeenSeen = false;
+
+    public AppIconHideHelper(Activity activity) {
+        mActivity = activity;
+    }
+
+    public void setCheckBox(CheckBox checkBox) {
+        mCheckBox = checkBox;
+
+        // Setup checkBox state
+        boolean currentSetting = PreferenceManager.getDefaultSharedPreferences(mActivity)
+                .getBoolean("AppIconHidden", false);
+        checkBox.setChecked(currentSetting);
+    }
+
+    public void setCheckBoxEnabled(boolean enabled) {
+        mCheckBox.setEnabled(enabled);
+        if (!enabled) {
+            mCheckBox.setChecked(false);
+        }
+    }
+
+    public void startListeningForChanges() {
+        mCheckBox.setOnCheckedChangeListener(this);
+    }
+
+    @Override
+    public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
+
+        // Show warning dialog on first time
+        if (!mDialogHasBeenSeen && isChecked) {
+            mDialogHasBeenSeen = true;
+
+            AlertDialog.Builder db = new AlertDialog.Builder(mActivity);
+            db.setMessage(R.string.icon_warning);
+
+            // "Yes" button
+            db.setPositiveButton(R.string.yes, new DialogInterface.OnClickListener() {
+                @Override
+                public void onClick(DialogInterface dialog, int which) {
+                    changeIconVisibility(true); // Hide icon
+                }
+            });
+
+            // "No" button
+            db.setNegativeButton(R.string.no, new DialogInterface.OnClickListener() {
+                @Override
+                public void onClick(DialogInterface dialog, int which) {
+                    mCheckBox.setChecked(false); // Un-check the CheckBox
+                    mDialogHasBeenSeen = false; // Clear flag.
+                }
+            });
+
+            // Show the dialog
+            db.show();
+
+        } else {
+            // The warning has already been seen, or they are disabling the setting (so no warning
+            // is needed).
+            changeIconVisibility(isChecked);
+        }
+    }
+
+    private void changeIconVisibility(boolean hidden) {
+        PackageManager pm = mActivity.getPackageManager();
+        final int flags = PackageManager.DONT_KILL_APP;
+        final String packageName = BuildConfig.APPLICATION_ID;
+
+        // The component name of the activitiy-alias component
+        final ComponentName alias = new ComponentName(packageName,
+                packageName + ".MainActivityAlias");
+
+        if (hidden) { // Hide launcher icon
+            final int stateDisabled = PackageManager.COMPONENT_ENABLED_STATE_DISABLED;
+            pm.setComponentEnabledSetting(alias, stateDisabled, flags);
+
+        } else { // Show launcher icon
+            final int stateEnabled = PackageManager.COMPONENT_ENABLED_STATE_ENABLED;
+            pm.setComponentEnabledSetting(alias, stateEnabled, flags);
+        }
+
+        // Save user setting
+        PreferenceManager.getDefaultSharedPreferences(mActivity)
+                .edit()
+                .putBoolean("AppIconHidden", hidden)
+                .apply();
+    }
+}

--- a/app/src/main/java/com/afzaln/awakedebug/MainActivity.java
+++ b/app/src/main/java/com/afzaln/awakedebug/MainActivity.java
@@ -9,6 +9,7 @@ import android.provider.Settings;
 import android.support.v7.app.AlertDialog;
 import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.SwitchCompat;
+import android.widget.CheckBox;
 import android.widget.CompoundButton;
 import android.widget.CompoundButton.OnCheckedChangeListener;
 import android.widget.Toast;
@@ -18,6 +19,7 @@ public class MainActivity extends AppCompatActivity {
 
     private static final int WRITE_SETTINGS_REQUEST = 1;
     private SwitchCompat mActionBarSwitch;
+    private AppIconHideHelper mIconHelper;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -25,10 +27,16 @@ public class MainActivity extends AppCompatActivity {
 
         setContentView(R.layout.activity_main);
 
+        // set up the "Hide app icon" checkbox
+        CheckBox checkBox = (CheckBox) findViewById(R.id.app_icon_checkbox);
+        mIconHelper = new AppIconHideHelper(this);
+        mIconHelper.setCheckBox(checkBox);
+
         mActionBarSwitch = (SwitchCompat) findViewById(R.id.toggle);
 
         boolean state = PowerConnectionReceiver.getPrefEnabled(getApplicationContext());
         mActionBarSwitch.setChecked(state);
+        mIconHelper.setCheckBoxEnabled(state); // Only enable "Hide app icon" if state is turned on.
         if (state) {
             mActionBarSwitch.setText("On");
         } else {
@@ -43,6 +51,7 @@ public class MainActivity extends AppCompatActivity {
                     mActionBarSwitch.setChecked(false);
                     return;
                 }
+                mIconHelper.setCheckBoxEnabled(isChecked);
 
                 PowerConnectionReceiver.setPrefEnabled(getApplicationContext(), isChecked);
                 if (!isChecked) {
@@ -54,6 +63,7 @@ public class MainActivity extends AppCompatActivity {
                 }
             }
         });
+        mIconHelper.startListeningForChanges();
     }
 
     @Override

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -68,4 +68,15 @@
         android:textStyle="italic"
         android:fontFamily="sans-serif-condensed" />
 
+    <CheckBox
+        android:id="@+id/app_icon_checkbox"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_margin="16dp"
+        android:padding="8dp"
+        android:textSize="20sp"
+        android:textStyle="italic"
+        android:fontFamily="sans-serif-condensed"
+        android:text="@string/icon_checkbox_text" />
+
 </LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -6,4 +6,10 @@
     <string name="intro_2">It switches to the previously set display timeout when the device is unplugged or if it\'s plugged to the wall.</string>
     <string name="action_settings">Settings</string>
 
+    <!-- Text dealing with the "Hide app icon" checkbox. -->
+    <string name="icon_checkbox_text">Remove app icon from launcher.</string>
+    <string name="icon_warning">Awake for Debug will continue to work in the background, but you will have to uninstall and reinstall the app if you want to get the app icon back in the launcher. Continue?</string>
+    <string name="yes">Yes</string>
+    <string name="no">No</string>
+
 </resources>


### PR DESCRIPTION
Great app, @AfzalivE.
Because I dislike clutter on my phone, I added an option to hide the app's launcher icon while still letting it run in the background.

Unfortunately, I can't find an easy way that the user can undo that action
without uninstalling and reinstalling the app. However, seeing as this app can easily require only one-time setup, I figured you might still be interested in merging my changes into the published app.

(One idea for future implementation would be to add a low-priority notification that appears whenever a
USB connection is established, telling the user, "The screen timeout is disabled while USB debugging is connected. Tap here to configure.")

Here are a few screenshots:
![device-2016-06-11-175943](https://cloud.githubusercontent.com/assets/1236809/15988031/77c99df6-2ffe-11e6-8694-2b4ff83d6650.png)
![device-2016-06-11-180034](https://cloud.githubusercontent.com/assets/1236809/15988032/77c9a1e8-2ffe-11e6-8a43-80e45a4e0a10.png)
