### PR TITLE
feat: app shortcuts api >25, ac power mode, fix: dependencies upgrade

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -8,12 +8,12 @@ repositories {
 
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion "23.0.2"
+    compileSdkVersion 25
+    buildToolsVersion '25.0.2'
 
     defaultConfig {
         minSdkVersion 14
-        targetSdkVersion 23
+        targetSdkVersion 25
         versionCode 4
         versionName "1.3"
     }
@@ -44,8 +44,8 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:design:23.1.1'
-    compile 'com.android.support:appcompat-v7:23.1.1'
+    compile 'com.android.support:design:25.3.0'
+    compile 'com.android.support:appcompat-v7:25.3.0'
     compile('com.crashlytics.sdk.android:crashlytics:2.5.5@aar') {
         transitive = true
     }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -36,6 +36,11 @@
                 <action android:name="android.intent.action.ACTION_POWER_DISCONNECTED"/>
             </intent-filter>
         </receiver>
+
+        <meta-data
+            android:name="io.fabric.ApiKey"
+            android:value="ca849bf6cdd88797c30d095ddef12b71cc2ce64c" />
+
     </application>
 
 </manifest>

--- a/app/src/main/java/com/afzaln/awakedebug/PowerConnectionReceiver.java
+++ b/app/src/main/java/com/afzaln/awakedebug/PowerConnectionReceiver.java
@@ -32,8 +32,16 @@ public class PowerConnectionReceiver extends BroadcastReceiver {
         Intent batteryStatus = context.getApplicationContext().registerReceiver(null, filter);
 
         int chargePlug = batteryStatus.getIntExtra(BatteryManager.EXTRA_PLUGGED, -1);
-        boolean usbCharge = chargePlug == BatteryManager.BATTERY_PLUGGED_USB ||
-                (chargePlug == BatteryManager.BATTERY_PLUGGED_AC && Utils.getAcPowerOn(context));
+        boolean usbCharge;
+
+        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.JELLY_BEAN_MR1) {
+            usbCharge = chargePlug == BatteryManager.BATTERY_PLUGGED_USB ||
+                    chargePlug == BatteryManager.BATTERY_PLUGGED_WIRELESS ||
+                    (chargePlug == BatteryManager.BATTERY_PLUGGED_AC && Utils.getAcPowerOn(context));
+        } else {
+            usbCharge = chargePlug == BatteryManager.BATTERY_PLUGGED_USB ||
+                    (chargePlug == BatteryManager.BATTERY_PLUGGED_AC && Utils.getAcPowerOn(context));
+        }
 
         int adb;
         if (VERSION.SDK_INT < VERSION_CODES.JELLY_BEAN_MR1) {

--- a/app/src/main/java/com/afzaln/awakedebug/PowerConnectionReceiver.java
+++ b/app/src/main/java/com/afzaln/awakedebug/PowerConnectionReceiver.java
@@ -32,7 +32,8 @@ public class PowerConnectionReceiver extends BroadcastReceiver {
         Intent batteryStatus = context.getApplicationContext().registerReceiver(null, filter);
 
         int chargePlug = batteryStatus.getIntExtra(BatteryManager.EXTRA_PLUGGED, -1);
-        boolean usbCharge = chargePlug == BatteryManager.BATTERY_PLUGGED_USB;
+        boolean usbCharge = chargePlug == BatteryManager.BATTERY_PLUGGED_USB ||
+                (chargePlug == BatteryManager.BATTERY_PLUGGED_AC && Utils.getAcPowerOn(context));
 
         int adb;
         if (VERSION.SDK_INT < VERSION_CODES.JELLY_BEAN_MR1) {

--- a/app/src/main/java/com/afzaln/awakedebug/Utils.java
+++ b/app/src/main/java/com/afzaln/awakedebug/Utils.java
@@ -1,0 +1,25 @@
+package com.afzaln.awakedebug;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.preference.PreferenceManager;
+
+/**
+ * A complimentary utility class.
+ * Created by Dmytro Karataiev on 3/29/17.
+ */
+public class Utils {
+
+    static void setAcPowerOn(Context context, boolean isChecked) {
+        SharedPreferences sharedPreferences = PreferenceManager.getDefaultSharedPreferences(context);
+        sharedPreferences
+                .edit()
+                .putBoolean(context.getString(R.string.sharedpref_ac_key), isChecked)
+                .apply();
+    }
+
+    public static boolean getAcPowerOn(Context context) {
+        SharedPreferences sharedPreferences = PreferenceManager.getDefaultSharedPreferences(context);
+        return sharedPreferences.getBoolean(context.getString(R.string.sharedpref_ac_key), false);
+    }
+}

--- a/app/src/main/res/drawable/ic_check_box.xml
+++ b/app/src/main/res/drawable/ic_check_box.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+        android:fillColor="#FF929292"
+        android:pathData="M19,3L5,3c-1.11,0 -2,0.9 -2,2v14c0,1.1 0.89,2 2,2h14c1.11,0 2,-0.9 2,-2L21,5c0,-1.1 -0.89,-2 -2,-2zM10,17l-5,-5 1.41,-1.41L10,14.17l7.59,-7.59L19,8l-9,9z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_check_box_blank.xml
+++ b/app/src/main/res/drawable/ic_check_box_blank.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+        android:fillColor="#FF929292"
+        android:pathData="M19,5v14H5V5h14m0,-2H5c-1.1,0 -2,0.9 -2,2v14c0,1.1 0.9,2 2,2h14c1.1,0 2,-0.9 2,-2V5c0,-1.1 -0.9,-2 -2,-2z"/>
+</vector>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -25,20 +25,30 @@
 
     <LinearLayout
         android:layout_width="match_parent"
-        android:layout_height="56dp"
-        android:orientation="horizontal"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
         android:background="@color/switch_bar">
 
 
         <android.support.v7.widget.SwitchCompat
             android:id="@+id/toggle"
             android:layout_width="match_parent"
-            android:layout_height="match_parent"
+            android:layout_height="@dimen/switch_height"
             android:textSize="18sp"
             android:paddingLeft="@dimen/activity_horizontal_margin"
             android:paddingRight="@dimen/activity_horizontal_margin"
             android:textColor="@android:color/white"
             android:text="On" />
+
+        <android.support.v7.widget.SwitchCompat
+            android:id="@+id/toggle_ac"
+            android:layout_width="match_parent"
+            android:layout_height="@dimen/switch_height"
+            android:textSize="18sp"
+            android:paddingLeft="@dimen/activity_horizontal_margin"
+            android:paddingRight="@dimen/activity_horizontal_margin"
+            android:textColor="@android:color/white"
+            android:text="@string/on_ac_desc" />
 
     </LinearLayout>
 

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -3,4 +3,5 @@
     <dimen name="activity_horizontal_margin">16dp</dimen>
     <dimen name="activity_vertical_margin">16dp</dimen>
     <dimen name="action_bar_switch_padding">4dp</dimen>
+    <dimen name="switch_height">56dp</dimen>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -11,5 +11,20 @@
     <string name="icon_warning">Awake for Debug will continue to work in the background, but you will have to uninstall and reinstall the app if you want to get the app icon back in the launcher. Continue?</string>
     <string name="yes">Yes</string>
     <string name="no">No</string>
+    <string name="on_ac_desc">On when connected to AC</string>
+
+    <!-- SharedPref key which controls if to stay awake when connected to AC -->
+    <string name="sharedpref_ac_key">on_ac</string>
+
+    <!-- Shortcut strings -->
+    <string name="awake_disabled">Awake Disabled</string>
+    <string name="awake_toggle_long">Toggle Stay Awake Mode</string>
+    <string name="awake_toggle_short">Toggle Awake</string>
+
+    <string name="awake_ac_disabled">Awake AC Disabled</string>
+    <string name="awake_ac_toggle_long">Toggle AC Stay Awake Mode</string>
+    <string name="awake_ac_toggle_short">Toggle AC Awake</string>
+    <string name="awake_key">toggle_awake</string>
+    <string name="awake_ac_key">toggle_ac_awake</string>
 
 </resources>

--- a/build.gradle
+++ b/build.gradle
@@ -6,8 +6,8 @@ buildscript {
         maven { url 'https://maven.fabric.io/public' }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.5.0'
-        classpath 'io.fabric.tools:gradle:1.+'
+        classpath 'com.android.tools.build:gradle:2.3.0'
+        classpath 'io.fabric.tools:gradle:1.22.1'
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         maven { url 'https://maven.fabric.io/public' }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.0'
+        classpath 'com.android.tools.build:gradle:2.3.3'
         classpath 'io.fabric.tools:gradle:1.22.1'
     }
 }


### PR DESCRIPTION
This PR is just FYI. I find this app extremely useful, but I was missing some things, which I've implemented in this PR:

1. Sometimes I need a phone not to sleep when connected to AC (e.g. when I'm using a usb hub).
2. On devices with API >25 - shortcuts are very convenient. Screenshots are below:

![screenshot_20170329-151543](https://cloud.githubusercontent.com/assets/14958724/24479188/d93ec1f0-1492-11e7-9a67-d05c9faa6563.png)
![screenshot_20170329-151551](https://cloud.githubusercontent.com/assets/14958724/24479189/d941a046-1492-11e7-9185-ba9deda29ff3.png)

