### PR TITLE
Fixed incorrect display timeout in UI

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -16,8 +16,8 @@ android {
     defaultConfig {
         minSdkVersion 27
         targetSdkVersion 30
-        versionCode 12
-        versionName "2.0"
+        versionCode 13
+        versionName "2.1"
     }
 
     buildFeatures {

--- a/app/src/main/java/com/afzaln/awakedebug/NotificationListener.kt
+++ b/app/src/main/java/com/afzaln/awakedebug/NotificationListener.kt
@@ -30,7 +30,7 @@ class NotificationListener : NotificationListenerService() {
 
             toggleController.toggleFromNotification(visibleDebugNotifications)
         } catch (ex: SecurityException) {
-            Timber.e(ex)
+            Timber.e(ex, "Unable to get active notifications")
         }
     }
 }

--- a/app/src/main/java/com/afzaln/awakedebug/data/Prefs.kt
+++ b/app/src/main/java/com/afzaln/awakedebug/data/Prefs.kt
@@ -9,6 +9,7 @@ import timber.log.Timber
 private const val KEY_USB_DEBUG_ENABLED = "UsbDebugEnabled"
 private const val KEY_WIFI_DEBUG_ENABLED = "WifiDebugEnabled"
 private const val KEY_AWAKE_DEBUG_ENABLED = "AwakeDebugEnabled"
+private const val KEY_AWAKE_DEBUG_ACTIVE = "AwakeDebugActive"
 private const val KEY_DISPLAY_TIMEOUT = "DisplayTimeout"
 
 /**
@@ -61,6 +62,17 @@ class Prefs(val app: AwakeDebugApp) {
         set(value) {
             Timber.d("Setting $KEY_AWAKE_DEBUG_ENABLED: %s", value)
             preferences.edit().putBoolean(KEY_AWAKE_DEBUG_ENABLED, value).apply()
+        }
+
+    var awakeDebugActive: Boolean
+        get() {
+            val awakeDebugActive = preferences.getBoolean(KEY_AWAKE_DEBUG_ACTIVE, false)
+            Timber.d("$KEY_AWAKE_DEBUG_ACTIVE: %s", awakeDebugActive)
+            return awakeDebugActive
+        }
+        set(value) {
+            Timber.d("Setting $KEY_AWAKE_DEBUG_ACTIVE: %s", value)
+            preferences.edit().putBoolean(KEY_AWAKE_DEBUG_ACTIVE, value).apply()
         }
 
     var savedTimeout: Int

--- a/app/src/main/java/com/afzaln/awakedebug/data/SystemSettings.kt
+++ b/app/src/main/java/com/afzaln/awakedebug/data/SystemSettings.kt
@@ -47,11 +47,6 @@ class SystemSettings(
             return 0
         }
 
-    // this can also be true if user has manually
-    // selected 30 minutes as display timeout
-    private val isAwakeDebugActive: Boolean
-        get() = screenOffTimeout == MAX_TIMEOUT
-
     fun refreshScreenTimeout() {
         if (hasModifyPermission) {
             screenTimeoutLiveData.value = screenOffTimeout
@@ -59,7 +54,7 @@ class SystemSettings(
         }
     }
 
-    fun extendScreenTimeout() {
+    internal fun extendScreenTimeout() {
         if (hasModifyPermission) {
             prefs.savedTimeout = screenOffTimeout
             Settings.System.putInt(app.contentResolver, Settings.System.SCREEN_OFF_TIMEOUT, MAX_TIMEOUT)
@@ -68,7 +63,7 @@ class SystemSettings(
         }
     }
 
-    fun restoreScreenTimeout() {
+    internal fun restoreScreenTimeout() {
         if (hasModifyPermission) {
             Settings.System.putInt(app.contentResolver, Settings.System.SCREEN_OFF_TIMEOUT, prefs.savedTimeout)
             Timber.d("Screen timeout is now ${prefs.savedTimeout}")

--- a/app/src/main/java/com/afzaln/awakedebug/data/SystemSettings.kt
+++ b/app/src/main/java/com/afzaln/awakedebug/data/SystemSettings.kt
@@ -47,8 +47,20 @@ class SystemSettings(
             return 0
         }
 
+    // this can also be true if user has manually
+    // selected 30 minutes as display timeout
+    private val isAwakeDebugActive: Boolean
+        get() = screenOffTimeout == MAX_TIMEOUT
+
+    fun refreshScreenTimeout() {
+        if (hasModifyPermission) {
+            screenTimeoutLiveData.value = screenOffTimeout
+            Timber.d("Refreshed screen timeout to ${screenTimeoutLiveData.value}")
+        }
+    }
+
     fun extendScreenTimeout() {
-        if (hasModifyPermission && screenOffTimeout < MAX_TIMEOUT) {
+        if (hasModifyPermission) {
             prefs.savedTimeout = screenOffTimeout
             Settings.System.putInt(app.contentResolver, Settings.System.SCREEN_OFF_TIMEOUT, MAX_TIMEOUT)
             Timber.d("Screen timeout is now $MAX_TIMEOUT")
@@ -57,7 +69,7 @@ class SystemSettings(
     }
 
     fun restoreScreenTimeout() {
-        if (hasModifyPermission && screenOffTimeout == MAX_TIMEOUT) {
+        if (hasModifyPermission) {
             Settings.System.putInt(app.contentResolver, Settings.System.SCREEN_OFF_TIMEOUT, prefs.savedTimeout)
             Timber.d("Screen timeout is now ${prefs.savedTimeout}")
             screenTimeoutLiveData.value = prefs.savedTimeout

--- a/app/src/main/java/com/afzaln/awakedebug/data/ToggleController.kt
+++ b/app/src/main/java/com/afzaln/awakedebug/data/ToggleController.kt
@@ -24,6 +24,11 @@ class ToggleController(
         toggle(prefs.awakeDebug)
     }
 
+    /**
+     * Extends or Restores system screen timeout based
+     * on the notifications, the awake debug toggle,
+     * and the current state of awake debug.
+     */
     fun toggle(shouldEnable: Boolean) {
         prefs.awakeDebug = shouldEnable
         val enabledDebugNotificationsExist = visibleDebugNotifications.value?.any {
@@ -31,11 +36,17 @@ class ToggleController(
         } ?: false
 
         if (shouldEnable && enabledDebugNotificationsExist) {
-            Timber.d("Debugging enabled")
-            systemSettings.extendScreenTimeout()
+            if (!prefs.awakeDebugActive) {
+                Timber.d("Debugging enabled")
+                systemSettings.extendScreenTimeout()
+                prefs.awakeDebugActive = true
+            }
         } else {
-            Timber.d("Debugging disabled")
-            systemSettings.restoreScreenTimeout()
+            if (prefs.awakeDebugActive) {
+                Timber.d("Debugging disabled")
+                systemSettings.restoreScreenTimeout()
+                prefs.awakeDebugActive = false
+            }
         }
     }
 }

--- a/app/src/main/java/com/afzaln/awakedebug/ui/ToggleFragment.kt
+++ b/app/src/main/java/com/afzaln/awakedebug/ui/ToggleFragment.kt
@@ -54,6 +54,8 @@ class ToggleFragment : Fragment() {
 
         if (!systemSettings.hasAllPermissions) {
             (activity as MainActivity).navigateToPermissionFragment()
+        } else {
+            systemSettings.refreshScreenTimeout()
         }
     }
 
@@ -72,6 +74,7 @@ class ToggleFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
+        // no wireless debugging type in versions below Android R
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
             binding.debuggingTypeGroup.visibility = View.VISIBLE
             binding.debuggingTypeLabel.visibility = View.VISIBLE

--- a/app/src/main/java/com/afzaln/awakedebug/ui/ToggleViewModel.kt
+++ b/app/src/main/java/com/afzaln/awakedebug/ui/ToggleViewModel.kt
@@ -47,7 +47,6 @@ class ToggleViewModel(
     }
 
     fun setDebugAwake(shouldEnable: Boolean) {
-        prefs.awakeDebug = shouldEnable
         toggleController.toggle(shouldEnable)
         shortcuts.updateShortcuts()
 

--- a/whatsnew/whatsnew-en-US
+++ b/whatsnew/whatsnew-en-US
@@ -3,3 +3,5 @@ ACTION_POWER_CONNECTED from background in API 26, this nifty app
 returns with support for the magic of wireless debugging on
 Android 11 and a newfound interest in debugging notifications
 to find out if debugging is active on the device. 🎉
+
+- Fixed incorrect display timeout in UI when opening the app sometimes


### PR DESCRIPTION
- Need to refresh system screen timeout when resuming the app.
- Remove timeout checks when modifying system timeout because ToggleController already checks if awakeDebug is enabled